### PR TITLE
Correctly load supergame cart types

### DIFF
--- a/Core/Cartridge.cpp
+++ b/Core/Cartridge.cpp
@@ -70,6 +70,12 @@ static bool cartridge_CC2(const byte* header) {
 // GetBankOffset
 // ----------------------------------------------------------------------------
 static uint cartridge_GetBankOffset(byte bank) {
+  if ((cartridge_type == CARTRIDGE_TYPE_SUPERCART || cartridge_type == CARTRIDGE_TYPE_SUPERCART_ROM || cartridge_type == CARTRIDGE_TYPE_SUPERCART_RAM) && cartridge_size <= 65536) {
+    // for some of these carts, there are only 4 banks. in this case we ignore bit 3
+    // previously, games of this type had to be doubled. The first 4 banks needed to be duplicated at the end of the ROM
+      return (bank & 3) * 16384;
+  }
+  
   return bank * 16384;
 }
 


### PR DESCRIPTION
This was a long-standing issue with ProSystem and the "supergame" cart types.

Fixes loading of good ROM dumps where previously only their overdumps would load (Tower Toppler, Realsports Baseball, Water Ski, etc)

Patch credits to Joseph Zatarski of ##Atari on Freenode IRC